### PR TITLE
Search Input: Add hover effect

### DIFF
--- a/src/components/SearchInput/SearchInput.jsx
+++ b/src/components/SearchInput/SearchInput.jsx
@@ -51,7 +51,7 @@ const Input = glamorous.input(
       boxShadow: `${shadows[0]}, ${shadows[1]}`,
       transition: `box-shadow ${transition.duration} ${transition.easing}`,
 
-      ':hover, :focus': {
+      '&:hover, &:focus': {
          boxShadow: `${shadows[0]}, ${shadows[2]}`,
       },
 

--- a/src/components/SearchInput/SearchInput.jsx
+++ b/src/components/SearchInput/SearchInput.jsx
@@ -21,6 +21,7 @@ const IconContainer = glamorous.div({
    left: 0,
    display: 'flex',
    alignItems: 'center',
+   pointerEvents: 'none',
 });
 
 const SearchIcon = glamorous(Icon, { withProps: { name: 'search' } })({
@@ -64,6 +65,7 @@ const Input = glamorous.input(
          color: color.grayAlpha[5],
          backgroundColor: color.grayAlpha[1],
          boxShadow: `inset ${shadows[0]}`,
+         pointerEvents: 'none',
       },
 );
 

--- a/src/components/SearchInput/SearchInput.jsx
+++ b/src/components/SearchInput/SearchInput.jsx
@@ -50,7 +50,7 @@ const Input = glamorous.input(
       boxShadow: `${shadows[0]}, ${shadows[1]}`,
       transition: `box-shadow ${transition.duration} ${transition.easing}`,
 
-      ':focus': {
+      ':hover, :focus': {
          boxShadow: `${shadows[0]}, ${shadows[2]}`,
       },
 

--- a/src/components/SearchInput/SearchInput.jsx
+++ b/src/components/SearchInput/SearchInput.jsx
@@ -38,7 +38,7 @@ const Input = glamorous.input(
       display: 'block',
       width: '100%',
       margin: 0,
-      // 56px is used instead of a spacing constat to exactly match the SearchIcon width
+      // 56px is used instead of a spacing constant to exactly match the SearchIcon width
       padding: `${spacing[2]} ${spacing[3]} ${spacing[2]} 56px`,
       fontFamily: 'inherit',
       fontSize: fontSize[2],
@@ -55,7 +55,7 @@ const Input = glamorous.input(
          boxShadow: `${shadows[0]}, ${shadows[2]}`,
       },
 
-      // this removes the extra left padding added to search inputs on Safari
+      // removes the extra left padding added to search inputs on Safari
       '::-webkit-search-decoration': {
          display: 'none',
       },

--- a/src/components/SearchInput/__snapshots__/SearchInput.test.jsx.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.test.jsx.snap
@@ -56,8 +56,10 @@ exports[`renders when disabled 1`] = `
   -moz-transition: box-shadow 150ms ease-in-out;
 }
 
-.glamor-2:focus,
-[data-glamor-2]:focus {
+.glamor-2:hover,
+[data-glamor-2]:hover,
+.glamor-2 :focus,
+[data-glamor-2] :focus {
   box-shadow: 0 0 0 1px rgba(0, 3, 6, 0.12), 0 4px 8px 0 rgba(0, 3, 6, 0.12), 0 2px 4px 0 rgba(0, 3, 6, 0.07);
 }
 
@@ -151,8 +153,10 @@ exports[`renders without crashing 1`] = `
   -moz-transition: box-shadow 150ms ease-in-out;
 }
 
-.glamor-2:focus,
-[data-glamor-2]:focus {
+.glamor-2:hover,
+[data-glamor-2]:hover,
+.glamor-2 :focus,
+[data-glamor-2] :focus {
   box-shadow: 0 0 0 1px rgba(0, 3, 6, 0.12), 0 4px 8px 0 rgba(0, 3, 6, 0.12), 0 2px 4px 0 rgba(0, 3, 6, 0.07);
 }
 

--- a/src/components/SearchInput/__snapshots__/SearchInput.test.jsx.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.test.jsx.snap
@@ -18,6 +18,7 @@ exports[`renders when disabled 1`] = `
   display: -webkit-flex;
   display: flex;
   align-items: center;
+  pointer-events: none;
   -webkit-box-align: center;
   -webkit-align-items: center;
 }
@@ -52,6 +53,7 @@ exports[`renders when disabled 1`] = `
   outline: none;
   box-shadow: inset 0 0 0 1px rgba(0, 3, 6, 0.12);
   transition: box-shadow 150ms ease-in-out;
+  pointer-events: none;
   -webkit-transition: box-shadow 150ms ease-in-out;
   -moz-transition: box-shadow 150ms ease-in-out;
 }
@@ -115,6 +117,7 @@ exports[`renders without crashing 1`] = `
   display: -webkit-flex;
   display: flex;
   align-items: center;
+  pointer-events: none;
   -webkit-box-align: center;
   -webkit-align-items: center;
 }

--- a/src/components/SearchInput/__snapshots__/SearchInput.test.jsx.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.test.jsx.snap
@@ -60,8 +60,8 @@ exports[`renders when disabled 1`] = `
 
 .glamor-2:hover,
 [data-glamor-2]:hover,
-.glamor-2 :focus,
-[data-glamor-2] :focus {
+.glamor-2:focus,
+[data-glamor-2]:focus {
   box-shadow: 0 0 0 1px rgba(0, 3, 6, 0.12), 0 4px 8px 0 rgba(0, 3, 6, 0.12), 0 2px 4px 0 rgba(0, 3, 6, 0.07);
 }
 
@@ -158,8 +158,8 @@ exports[`renders without crashing 1`] = `
 
 .glamor-2:hover,
 [data-glamor-2]:hover,
-.glamor-2 :focus,
-[data-glamor-2] :focus {
+.glamor-2:focus,
+[data-glamor-2]:focus {
   box-shadow: 0 0 0 1px rgba(0, 3, 6, 0.12), 0 4px 8px 0 rgba(0, 3, 6, 0.12), 0 2px 4px 0 rgba(0, 3, 6, 0.07);
 }
 


### PR DESCRIPTION
This applies the same effect that was currently applied to `:focus` to `:hover` as well.

### regular:
![image](https://user-images.githubusercontent.com/10774982/36881233-f1693fa0-1d81-11e8-9ac2-3f175c5f2dc0.png)


### hover/focus:
![image](https://user-images.githubusercontent.com/10774982/36881242-fda1b63a-1d81-11e8-96bd-bdb1c197d388.png)


## QA 
- go to https://deploy-preview-34--toolbox.netlify.com/#searchinput and ensure that the drop shadow adjusts when you hover over or click on `<SearchInput>`
- make sure that the hover effect is not applied to the disabled input