### PR TITLE
Add Avatar component

### DIFF
--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { oneOfType, string, number } from 'prop-types';
+import glamorous from 'glamorous';
+
+const AvatarContainer = glamorous.img(props => ({
+   width: props.size,
+   height: props.size,
+   borderRadius: '50%',
+}));
+
+const Avatar = props => <AvatarContainer {...props} />;
+
+Avatar.propTypes = {
+   /** The avatar image URL. */
+   src: string.isRequired,
+   /**
+    * The width and height of the avatar.
+    * A number will be interpreted as a pixel value.
+    * Use a string to specify other units (e.g. "2em").
+    * */
+   size: oneOfType([string, number]),
+};
+
+Avatar.defaultProps = {
+   size: 48,
+};
+
+export default Avatar;

--- a/src/components/Avatar/Avatar.test.jsx
+++ b/src/components/Avatar/Avatar.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Avatar from './Avatar';
+
+test('renders without crashing', () => {
+   const tree = renderer
+      .create(<Avatar src="http://via.placeholder.com/100x100" />)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with custom size (number)', () => {
+   const tree = renderer
+      .create(<Avatar src="http://via.placeholder.com/100x100" size={32} />)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with custom size (string)', () => {
+   const tree = renderer
+      .create(<Avatar src="http://via.placeholder.com/100x100" size="4rem" />)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -1,0 +1,21 @@
+### Examples
+
+#### Default Avatar
+```
+<Avatar src="https://d3nevzfk7ii3be.cloudfront.net/igi/MrphvTGGRcKHXRV2.standard" />
+```
+
+#### Custom sizes
+```
+<Avatar
+   src="https://d3nevzfk7ii3be.cloudfront.net/igi/kYipBhTkDKX4aXIY.standard"
+   size={32}
+/>
+```
+
+```
+<Avatar
+   src="https://d3nevzfk7ii3be.cloudfront.net/igi/kYipBhTkDKX4aXIY.standard"
+   size="4rem"
+/>
+```

--- a/src/components/Avatar/__snapshots__/Avatar.test.jsx.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.test.jsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders with custom size (number) 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+}
+
+<img
+  className="glamor-0"
+  src="http://via.placeholder.com/100x100"
+/>
+`;
+
+exports[`renders with custom size (string) 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  width: 4rem;
+  height: 4rem;
+  border-radius: 50%;
+}
+
+<img
+  className="glamor-0"
+  src="http://via.placeholder.com/100x100"
+/>
+`;
+
+exports[`renders without crashing 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
+
+<img
+  className="glamor-0"
+  src="http://via.placeholder.com/100x100"
+/>
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import './plugins';
  * */
 export { default as glamorous } from 'glamorous';
 
+export { default as Avatar } from './components/Avatar/Avatar';
 export { default as Button } from './components/Button/Button';
 export { default as Checkbox } from './components/Checkbox/Checkbox';
 export { default as Grid } from './components/Grid/Grid';


### PR DESCRIPTION
Summary
---

This pull adds a circular `Avatar` component to Toolbox.

![image](https://user-images.githubusercontent.com/4608155/36994187-2cfaa4e2-2065-11e8-8882-0a7bada897e5.png)

QA
---
* Go to https://deploy-preview-36--toolbox.netlify.com/#avatar
* Assert that the `Avatar` section matches the screenshot above.