### PR TITLE
Tabs: Use mask-image property to achieve horizontal fade effect

### DIFF
--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -7,21 +7,7 @@ import constants from '../../constants';
 const { color, spacing } = constants;
 
 const Container = glamorous.div({
-   position: 'relative',
    borderBottom: `1px solid ${color.grayAlpha[3]}`,
-
-   ':after': {
-      content: '""',
-      display: 'block',
-      position: 'absolute',
-      top: 0,
-      bottom: 0,
-      right: 0,
-      width: spacing[2],
-      background: `linear-gradient(to left, ${
-         color.white
-      }, rgba(255, 255, 255, 0))`,
-   },
 });
 
 const ScrollContainer = glamorous.div({
@@ -30,14 +16,17 @@ const ScrollContainer = glamorous.div({
    overflowX: 'auto',
    overflowY: 'hidden',
    WebkitOverflowScrolling: 'touch',
+   maskImage: `linear-gradient(to left, transparent, ${color.black} ${
+      spacing[2]
+   })`,
 });
 
 const TabsWrapper = glamorous.div({
    display: 'flex',
 });
 
-const Tabs = ({ children, ...rest }) => (
-   <Container {...rest}>
+const Tabs = ({ children, ...props }) => (
+   <Container {...props}>
       <ScrollContainer>
          <TabsWrapper>{children}</TabsWrapper>
       </ScrollContainer>

--- a/src/components/Tabs/Tabs.test.jsx
+++ b/src/components/Tabs/Tabs.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Tabs from './Tabs';
+import Tab from '../Tab/Tab';
+
+test('renders without crashing', () => {
+   const tree = renderer
+      .create(
+         <Tabs>
+            <Tab active>All</Tab>
+            <Tab>Store</Tab>
+            <Tab>Guides</Tab>
+            <Tab>Wikis</Tab>
+            <Tab>Devices</Tab>
+            <Tab>Answers</Tab>
+         </Tabs>,
+      )
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});

--- a/src/components/Tabs/__snapshots__/Tabs.test.jsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.test.jsx.snap
@@ -1,0 +1,144 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+.glamor-8,
+[data-glamor-8] {
+  border-bottom: 1px solid rgba(0, 3, 6, 0.12);
+}
+
+.glamor-7,
+[data-glamor-7] {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  align-items: center;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  mask-image: -webkit-linear-gradient(to left, transparent, #000000 0.75rem);
+  mask-image: -moz-linear-gradient(to left, transparent, #000000 0.75rem);
+  mask-image: linear-gradient(to left, transparent, #000000 0.75rem);
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -webkit-mask-image: -webkit-linear-gradient(to left, transparent, #000000 0.75rem);
+  -webkit-mask-image: -moz-linear-gradient(to left, transparent, #000000 0.75rem);
+  -webkit-mask-image: linear-gradient(to left, transparent, #000000 0.75rem);
+}
+
+.glamor-6,
+[data-glamor-6] {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  flex: 0 0 auto;
+  display: inline-block;
+  box-sizing: border-box;
+  padding: 0.75rem;
+  margin-right: 0.75rem;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
+  text-decoration: none;
+  color: #0071CE;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  transition: all 150ms ease-in-out;
+  outline: none;
+  border-bottom-color: #0071CE;
+  -webkit-flex: 0 0 auto;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-0:hover,
+[data-glamor-0]:hover {
+  color: #0071CE;
+}
+
+.glamor-0:focus,
+[data-glamor-0]:focus {
+  border-bottom-color: rgba(0, 3, 6, 0.26);
+}
+
+.glamor-1,
+[data-glamor-1] {
+  flex: 0 0 auto;
+  display: inline-block;
+  box-sizing: border-box;
+  padding: 0.75rem;
+  margin-right: 0.75rem;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
+  text-decoration: none;
+  color: rgba(0, 3, 6, 0.87);
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  transition: all 150ms ease-in-out;
+  outline: none;
+  -webkit-flex: 0 0 auto;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-1:hover,
+[data-glamor-1]:hover {
+  color: #0071CE;
+}
+
+.glamor-1:focus,
+[data-glamor-1]:focus {
+  border-bottom-color: rgba(0, 3, 6, 0.26);
+}
+
+<div
+  className="glamor-8"
+>
+  <div
+    className="glamor-7"
+  >
+    <div
+      className="glamor-6"
+    >
+      <a
+        className="glamor-0"
+      >
+        All
+      </a>
+      <a
+        className="glamor-1"
+      >
+        Store
+      </a>
+      <a
+        className="glamor-1"
+      >
+        Guides
+      </a>
+      <a
+        className="glamor-1"
+      >
+        Wikis
+      </a>
+      <a
+        className="glamor-1"
+      >
+        Devices
+      </a>
+      <a
+        className="glamor-1"
+      >
+        Answers
+      </a>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
This pull uses the `mask-image` CSS property to achieve horizontal fade effect instead of using a pseudo element. The benefit of using `mask-image` is that tabs now look good on all background colors, not just white.

## Before
![image](https://user-images.githubusercontent.com/4608155/37499562-a374fdb0-2881-11e8-994c-c904466741bd.png)

## After
![image](https://user-images.githubusercontent.com/4608155/37499615-e8d9e4e2-2881-11e8-8b17-a5c0d3a0ac2e.png)

## QA

* Go to https://deploy-preview-37--toolbox.netlify.com/#tabs
* Resize the viewport so the tabs overflow the container
* Assert that the right side of the tabs container has a fade effect (see screenshot)
* Assert consistency across supported browsers and devices