### PR TITLE
Add secondary button

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -21,7 +21,13 @@ const propTypes = {
       PropTypes.arrayOf(PropTypes.node),
    ]).isRequired,
    /** Choose a button design. */
-   design: PropTypes.oneOf(['default', 'primary', 'outline', 'plain']),
+   design: PropTypes.oneOf([
+      'default',
+      'primary',
+      'secondary',
+      'outline',
+      'plain',
+   ]),
    /** Disable button. */
    disabled: PropTypes.bool,
    /** Set width of the button to 100%. */
@@ -66,6 +72,16 @@ const designs = {
       },
       ':focus': {
          boxShadow: `0 0 0 3px ${color.blueAlpha[2]}`,
+      },
+   },
+   secondary: {
+      color: color.grayAlpha[9],
+      backgroundColor: color.grayAlpha[3],
+      ':hover': {
+         backgroundColor: color.grayAlpha[4],
+      },
+      ':focus': {
+         boxShadow: `0 0 0 3px ${color.grayAlpha[4]}`,
       },
    },
    outline: {

--- a/src/components/Button/Button.test.jsx
+++ b/src/components/Button/Button.test.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+import Button from './Button';
+
+test('renders without crashing', () => {
+   const tree = renderer.create(<Button>Test Button</Button>).toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders when disabled', () => {
+   const tree = renderer
+      .create(<Button disabled>Disabled Button</Button>)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with default design', () => {
+   const tree = renderer
+      .create(<Button design="default">Default Button</Button>)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with primary design', () => {
+   const tree = renderer
+      .create(<Button design="primary">Primary Button</Button>)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with secondary design', () => {
+   const tree = renderer
+      .create(<Button design="secondary">Secondary Button</Button>)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with outline design', () => {
+   const tree = renderer
+      .create(<Button design="outline">Outline Button</Button>)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with plain design', () => {
+   const tree = renderer
+      .create(<Button design="plain">Plain Button</Button>)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with small size', () => {
+   const tree = renderer
+      .create(<Button size="small">Small Button</Button>)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with large size', () => {
+   const tree = renderer
+      .create(<Button size="large">Large Button</Button>)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders at fullWidth', () => {
+   const tree = renderer
+      .create(<Button fullWidth>Full Width Button</Button>)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with a when href is present', () => {
+   const tree = renderer
+      .create(
+         <Button href="https://ifixit.com" target="_blank">
+            Go to iFixit.com
+         </Button>,
+      )
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('calls onClick when button is clicked', () => {
+   const handleClick = jest.fn();
+   const wrapper = mount(
+      <Button onClick={handleClick}>Clickable Button</Button>,
+   );
+   wrapper.find('button').simulate('click');
+   expect(handleClick).toHaveBeenCalledTimes(1);
+});

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -17,6 +17,10 @@
 ```
 
 ```
+<Button design="secondary">Secondary</Button>
+```
+
+```
 <Button design="outline">Outline</Button>
 ```
 

--- a/src/components/Button/__snapshots__/Button.test.jsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.jsx.snap
@@ -1,0 +1,936 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders at fullWidth 1`] = `
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: rgba(0, 3, 6, 0.87);
+  background-color: transparent;
+  border-color: rgba(0, 3, 6, 0.12);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  width: 100%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  background-color: rgba(0, 3, 6, 0.04);
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  box-shadow: 0 0 0 3px rgba(0, 3, 6, 0.12);
+}
+
+<button
+  className="glamor-2"
+  disabled={false}
+  onClick={[Function]}
+  tabIndex={0}
+>
+  <span
+    className="glamor-1"
+  >
+    <span
+      className="glamor-0"
+    >
+      Full Width Button
+    </span>
+  </span>
+</button>
+`;
+
+exports[`renders when disabled 1`] = `
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  display: inline-block;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: rgba(0, 3, 6, 0.87);
+  background-color: transparent;
+  border-color: rgba(0, 3, 6, 0.12);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  opacity: 0.5;
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  background-color: rgba(0, 3, 6, 0.04);
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  box-shadow: 0 0 0 3px rgba(0, 3, 6, 0.12);
+}
+
+<button
+  className="glamor-2"
+  disabled={true}
+  onClick={[Function]}
+  tabIndex={-1}
+>
+  <span
+    className="glamor-1"
+  >
+    <span
+      className="glamor-0"
+    >
+      Disabled Button
+    </span>
+  </span>
+</button>
+`;
+
+exports[`renders with a when href is present 1`] = `
+.glamor-2,
+[data-glamor-2] {
+  display: inline-block;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: rgba(0, 3, 6, 0.87);
+  background-color: transparent;
+  border-color: rgba(0, 3, 6, 0.12);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  background-color: rgba(0, 3, 6, 0.04);
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  box-shadow: 0 0 0 3px rgba(0, 3, 6, 0.12);
+}
+
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+<a
+  className="glamor-2"
+  href="https://ifixit.com"
+  onClick={[Function]}
+  tabIndex={0}
+  target="_blank"
+>
+  <span
+    className="glamor-1"
+  >
+    <span
+      className="glamor-0"
+    >
+      Go to iFixit.com
+    </span>
+  </span>
+</a>
+`;
+
+exports[`renders with default design 1`] = `
+.glamor-2,
+[data-glamor-2] {
+  display: inline-block;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: rgba(0, 3, 6, 0.87);
+  background-color: transparent;
+  border-color: rgba(0, 3, 6, 0.12);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  background-color: rgba(0, 3, 6, 0.04);
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  box-shadow: 0 0 0 3px rgba(0, 3, 6, 0.12);
+}
+
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+<button
+  className="glamor-2"
+  disabled={false}
+  onClick={[Function]}
+  tabIndex={0}
+>
+  <span
+    className="glamor-1"
+  >
+    <span
+      className="glamor-0"
+    >
+      Default Button
+    </span>
+  </span>
+</button>
+`;
+
+exports[`renders with large size 1`] = `
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  display: inline-block;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: rgba(0, 3, 6, 0.87);
+  background-color: transparent;
+  border-color: rgba(0, 3, 6, 0.12);
+  padding: 1rem 1.5rem;
+  font-size: 1rem;
+  line-height: 1.25;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  background-color: rgba(0, 3, 6, 0.04);
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  box-shadow: 0 0 0 3px rgba(0, 3, 6, 0.12);
+}
+
+<button
+  className="glamor-2"
+  disabled={false}
+  onClick={[Function]}
+  tabIndex={0}
+>
+  <span
+    className="glamor-1"
+  >
+    <span
+      className="glamor-0"
+    >
+      Large Button
+    </span>
+  </span>
+</button>
+`;
+
+exports[`renders with outline design 1`] = `
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  display: inline-block;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: #0071CE;
+  background-color: transparent;
+  border-color: #0071CE;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  color: #FFFFFF;
+  background-color: #0071CE;
+  border-color: #0071CE;
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  box-shadow: 0 0 0 3px rgba(0, 113, 206, 0.32);
+}
+
+<button
+  className="glamor-2"
+  disabled={false}
+  onClick={[Function]}
+  tabIndex={0}
+>
+  <span
+    className="glamor-1"
+  >
+    <span
+      className="glamor-0"
+    >
+      Outline Button
+    </span>
+  </span>
+</button>
+`;
+
+exports[`renders with plain design 1`] = `
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  display: inline-block;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: rgba(0, 3, 6, 0.87);
+  background-color: transparent;
+  border-color: transparent;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  color: #0071CE;
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  background-color: rgba(0, 3, 6, 0.04);
+}
+
+<button
+  className="glamor-2"
+  disabled={false}
+  onClick={[Function]}
+  tabIndex={0}
+>
+  <span
+    className="glamor-1"
+  >
+    <span
+      className="glamor-0"
+    >
+      Plain Button
+    </span>
+  </span>
+</button>
+`;
+
+exports[`renders with primary design 1`] = `
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  display: inline-block;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: #FFFFFF;
+  background-color: #0071CE;
+  border-color: #0071CE;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  color: #FFFFFF;
+  background-color: #005091;
+  border-color: #005091;
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  box-shadow: 0 0 0 3px rgba(0, 113, 206, 0.32);
+}
+
+<button
+  className="glamor-2"
+  disabled={false}
+  onClick={[Function]}
+  tabIndex={0}
+>
+  <span
+    className="glamor-1"
+  >
+    <span
+      className="glamor-0"
+    >
+      Primary Button
+    </span>
+  </span>
+</button>
+`;
+
+exports[`renders with secondary design 1`] = `
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  display: inline-block;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: rgba(0, 3, 6, 0.87);
+  background-color: rgba(0, 3, 6, 0.12);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  background-color: rgba(0, 3, 6, 0.26);
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  box-shadow: 0 0 0 3px rgba(0, 3, 6, 0.26);
+}
+
+<button
+  className="glamor-2"
+  disabled={false}
+  onClick={[Function]}
+  tabIndex={0}
+>
+  <span
+    className="glamor-1"
+  >
+    <span
+      className="glamor-0"
+    >
+      Secondary Button
+    </span>
+  </span>
+</button>
+`;
+
+exports[`renders with small size 1`] = `
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  display: inline-block;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: rgba(0, 3, 6, 0.87);
+  background-color: transparent;
+  border-color: rgba(0, 3, 6, 0.12);
+  padding: 0.25rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  background-color: rgba(0, 3, 6, 0.04);
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  box-shadow: 0 0 0 3px rgba(0, 3, 6, 0.12);
+}
+
+<button
+  className="glamor-2"
+  disabled={false}
+  onClick={[Function]}
+  tabIndex={0}
+>
+  <span
+    className="glamor-1"
+  >
+    <span
+      className="glamor-0"
+    >
+      Small Button
+    </span>
+  </span>
+</button>
+`;
+
+exports[`renders without crashing 1`] = `
+.glamor-2,
+[data-glamor-2] {
+  display: inline-block;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: rgba(0, 3, 6, 0.87);
+  background-color: transparent;
+  border-color: rgba(0, 3, 6, 0.12);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  background-color: rgba(0, 3, 6, 0.04);
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  box-shadow: 0 0 0 3px rgba(0, 3, 6, 0.12);
+}
+
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+<button
+  className="glamor-2"
+  disabled={false}
+  onClick={[Function]}
+  tabIndex={0}
+>
+  <span
+    className="glamor-1"
+  >
+    <span
+      className="glamor-0"
+    >
+      Test Button
+    </span>
+  </span>
+</button>
+`;


### PR DESCRIPTION
## Problem
The mockup for https://github.com/iFixit/ifixit/issues/23923 includes a style of button that we don't currently have. We need to add this button design to Toolbox before adding it to the search page.

This pull adds a new button style, named "secondary" with a flat gray background and black text.

**Regular**
![image](https://user-images.githubusercontent.com/10774982/38828302-7ffefd2a-416a-11e8-98ae-0594e7037613.png)

**Hover**
![image](https://user-images.githubusercontent.com/10774982/38828343-9afeb46c-416a-11e8-9d0c-6659ae97027e.png)

**Focus**
![image](https://user-images.githubusercontent.com/10774982/38828318-8fc7d5f6-416a-11e8-9d7b-cf21b08957e2.png)

## QA
Go to https://deploy-preview-38--toolbox.netlify.com/#button and ensure that the new button matches the screenshots above.