### PR TITLE
Add vertical button group

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.jsx
+++ b/src/components/ButtonGroup/ButtonGroup.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { arrayOf, bool, node } from 'prop-types';
+import { arrayOf, bool, node, string } from 'prop-types';
 import glamorous, { Div } from 'glamorous';
 
 import Button from '../Button/Button';
@@ -7,7 +7,7 @@ import constants from '../../constants';
 
 const { borderRadius } = constants;
 
-const ButtonGroupItem = glamorous(Button)({
+const ButtonGroupRowItem = glamorous(Button)({
    borderRadius: 0,
    borderRightWidth: 0,
 
@@ -22,14 +22,34 @@ const ButtonGroupItem = glamorous(Button)({
    },
 });
 
-const ButtonGroup = ({ children, disabled, ...props }) => (
-   <Div display="inline-block" {...props}>
+const ButtonGroupColumnItem = glamorous(Button)({
+   borderRadius: 0,
+   borderBottomWidth: 0,
+
+   '&:first-of-type': {
+      borderTopLeftRadius: borderRadius,
+      borderTopRightRadius: borderRadius,
+   },
+   '&:last-of-type': {
+      borderBottomLeftRadius: borderRadius,
+      borderBottomRightRadius: borderRadius,
+      borderBottomWidth: 1,
+   },
+});
+
+const ButtonGroup = ({ children, disabled, direction, ...props }) => (
+   <Div display="flex" flexDirection={direction} {...props}>
       {React.Children.map(children, child => {
          if (child.type !== Button) {
             return child;
          }
-         return (
-            <ButtonGroupItem
+         return direction === 'row' ? (
+            <ButtonGroupRowItem
+               {...child.props}
+               disabled={disabled || child.props.disabled}
+            />
+         ) : (
+            <ButtonGroupColumnItem
                {...child.props}
                disabled={disabled || child.props.disabled}
             />
@@ -41,12 +61,16 @@ const ButtonGroup = ({ children, disabled, ...props }) => (
 ButtonGroup.propTypes = {
    /** Buttons to be grouped together. */
    children: arrayOf(node).isRequired,
+   /** Indicated whether button group should display in as a row or
+    * stacked in a column */
+   direction: string,
    /** Indicates that the control is not available for interaction */
    disabled: bool,
 };
 
 ButtonGroup.defaultProps = {
    disabled: false,
+   direction: 'row',
 };
 
 export default ButtonGroup;

--- a/src/components/ButtonGroup/ButtonGroup.test.jsx
+++ b/src/components/ButtonGroup/ButtonGroup.test.jsx
@@ -51,3 +51,15 @@ test('renders with non-button children', () => {
       .toJSON();
    expect(tree).toMatchSnapshot();
 });
+
+test('renders as column', () => {
+   const tree = renderer
+      .create(
+         <ButtonGroup direction="column">
+            <Button>Button 1</Button>
+            <Button>Button 2</Button>
+         </ButtonGroup>,
+      )
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});

--- a/src/components/ButtonGroup/README.md
+++ b/src/components/ButtonGroup/README.md
@@ -1,7 +1,20 @@
-### Example
+### Examples
+
+#### Row
 
 ```
 <ButtonGroup>
+   <Button>File</Button>
+   <Button>Edit</Button>
+   <Button>View</Button>
+   <Button>History</Button>
+</ButtonGroup>
+```
+
+#### Column
+
+```
+<ButtonGroup direction="column">
    <Button>File</Button>
    <Button>Edit</Button>
    <Button>View</Button>

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.jsx.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.jsx.snap
@@ -1,9 +1,148 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders as column 1`] = `
+.glamor-1,
+[data-glamor-1] {
+  width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-1> :not(:first-child),
+[data-glamor-1]> :not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.glamor-6,
+[data-glamor-6] {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  display: inline-block;
+  box-sizing: border-box;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 0;
+  outline: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: all 150ms ease-in-out;
+  color: rgba(0, 3, 6, 0.87);
+  background-color: transparent;
+  border-color: rgba(0, 3, 6, 0.12);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-bottom-width: 0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2:hover,
+[data-glamor-2]:hover {
+  background-color: rgba(0, 3, 6, 0.04);
+}
+
+.glamor-2:focus,
+[data-glamor-2]:focus {
+  box-shadow: 0 0 0 3px rgba(0, 3, 6, 0.12);
+}
+
+.glamor-2:first-of-type,
+[data-glamor-2]:first-of-type {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.glamor-2:last-of-type,
+[data-glamor-2]:last-of-type {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border-bottom-width: 1px;
+}
+
+<div
+  className="glamor-6"
+>
+  <button
+    className="glamor-2"
+    disabled={false}
+    onClick={[Function]}
+    tabIndex={0}
+  >
+    <span
+      className="glamor-1"
+    >
+      <span
+        className="glamor-0"
+      >
+        Button 1
+      </span>
+    </span>
+  </button>
+  <button
+    className="glamor-2"
+    disabled={false}
+    onClick={[Function]}
+    tabIndex={0}
+  >
+    <span
+      className="glamor-1"
+    >
+      <span
+        className="glamor-0"
+      >
+        Button 2
+      </span>
+    </span>
+  </button>
+</div>
+`;
+
 exports[`renders when disabled 1`] = `
 .glamor-6,
 [data-glamor-6] {
-  display: inline-block;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: row;
 }
 
 .glamor-1,
@@ -128,7 +267,15 @@ exports[`renders when disabled 1`] = `
 exports[`renders with disabled children 1`] = `
 .glamor-6,
 [data-glamor-6] {
-  display: inline-block;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: row;
 }
 
 .glamor-5,
@@ -303,7 +450,15 @@ exports[`renders with disabled children 1`] = `
 exports[`renders with non-button children 1`] = `
 .glamor-6,
 [data-glamor-6] {
-  display: inline-block;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: row;
 }
 
 .glamor-2,
@@ -429,7 +584,15 @@ exports[`renders with non-button children 1`] = `
 exports[`renders without crashing 1`] = `
 .glamor-6,
 [data-glamor-6] {
-  display: inline-block;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: row;
 }
 
 .glamor-2,


### PR DESCRIPTION
Our existing `<ButtonGroup>` only supports buttons formatted in a row. This pull adds the option to format the `<ButtonGroup>` as a column of buttons instead. `<ButtonGroup>`  now takes in a `direction` prop which is either `"row"` or `"column"` and defaults to `"row"`.

![image](https://user-images.githubusercontent.com/10774982/38832823-9ea94664-4178-11e8-87c6-2dc6d4840634.png)

## QA
- Go to https://deploy-preview-39--toolbox.netlify.com/#buttongroup and ensure that the column button group matches the above screenshot.
- Confirm that the existing button group example (Row) has not changed. 
