### PR TITLE
Add PillBadge component

### DIFF
--- a/src/components/PillBadge/PillBadge.jsx
+++ b/src/components/PillBadge/PillBadge.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { string } from 'prop-types';
+import glamorous from 'glamorous';
+import constants from '../../constants';
+
+const { spacing, fontSize, lineHeight, color } = constants;
+
+const PillBadgeContainer = glamorous.span(props => ({
+   display: 'inline-block',
+   padding: `${spacing[0]} ${spacing[1]}`,
+   fontSize: fontSize[0],
+   fontWeight: 700,
+   lineHeight: lineHeight.none,
+   textTransform: 'uppercase',
+   color: props.color,
+   backgroundColor: props.background,
+   borderRadius: 9999,
+}));
+
+const PillBadge = props => <PillBadgeContainer {...props} />;
+
+PillBadge.propTypes = {
+   /** Set the background color. */
+   background: string,
+   /** Set the text color. */
+   color: string,
+};
+
+PillBadge.defaultProps = {
+   background: color.grayAlpha[1],
+   color: color.grayAlpha[6],
+};
+
+export default PillBadge;

--- a/src/components/PillBadge/PillBadge.test.jsx
+++ b/src/components/PillBadge/PillBadge.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import PillBadge from './PillBadge';
+
+test('renders without crashing', () => {
+   const tree = renderer.create(<PillBadge>Test</PillBadge>).toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with custom text color and background color', () => {
+   const tree = renderer
+      .create(
+         <PillBadge color="#C27E00" background="#FEF5D9">
+            Test
+         </PillBadge>,
+      )
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});

--- a/src/components/PillBadge/README.md
+++ b/src/components/PillBadge/README.md
@@ -1,0 +1,17 @@
+### Examples
+
+#### Default PillBadge
+
+```
+<PillBadge>42</PillBadge>
+```
+
+#### Alternate colors
+
+Remember to use the colors defined in the `constants` object instead of hard-coding HEX or RGBA values.
+
+```
+// NOTE: These colors are hard-coded for demo purposes only. Don't hard-code HEX values in production code.
+
+<PillBadge color="#C27E00" background="#FEF5D9">12K</PillBadge>
+```

--- a/src/components/PillBadge/__snapshots__/PillBadge.test.jsx.snap
+++ b/src/components/PillBadge/__snapshots__/PillBadge.test.jsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders with custom text color and background color 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: #C27E00;
+  background-color: #FEF5D9;
+  border-radius: 9999px;
+}
+
+<span
+  className="glamor-0"
+>
+  Test
+</span>
+`;
+
+exports[`renders without crashing 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: rgba(0, 3, 6, 0.54);
+  background-color: rgba(0, 3, 6, 0.04);
+  border-radius: 9999px;
+}
+
+<span
+  className="glamor-0"
+>
+  Test
+</span>
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export { default as Grid } from './components/Grid/Grid';
 export { default as Icon } from './components/Icon/Icon';
 export { default as Label } from './components/Label/Label';
 export { default as PageNavBar } from './components/PageNavBar/PageNavBar';
+export { default as PillBadge } from './components/PillBadge/PillBadge';
 export { default as Radio } from './components/Radio/Radio';
 export { default as RadioGroup } from './components/RadioGroup/RadioGroup';
 export { default as SearchInput } from './components/SearchInput/SearchInput';


### PR DESCRIPTION
This pull adds a `PillBadge` component to be used on the new search page.

![image](https://user-images.githubusercontent.com/4608155/39022997-0e70a71e-43ed-11e8-936e-e729ee1f19b7.png)

qa_req 0
I test this myself and it'll get re-QA'd on iFixit.