### PR TITLE
Toolbox: Fix 404 error when linking directly to a page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
Right now, if you navigate directly to a page on https://ifixit.design (e.g. https://ifixit.design/components/avatar), you get a 404. I'm pretty sure this is because `docz` is generating a Single Page App. To fix this error, we want to redirect all requests to `/index.html` and the JavaScript will determine what to render based of the `path`.

This pull adds the necessary config file to get Netlify to redirect all traffic to `/index.html`.

QA
---

* Go to the deploy preview: https://deploy-preview-49--toolbox.netlify.com
* Navigate to a component page (e.g. `Components > Avatar`)
* Assert reloading that page doesn't return a 404 error