### PR TITLE
Allow children and custom margin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 coverage
 .vscode
 .docz
+*.swp

--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -3,17 +3,29 @@ import PropTypes from 'prop-types';
 
 import CheckboxRadio from '../../internal/CheckboxRadio';
 
-const Checkbox = props => <CheckboxRadio type="checkbox" {...props} />;
+const Checkbox = ({ children, ...props }) => (
+   <CheckboxRadio type="checkbox" {...props}>
+      {children}
+   </CheckboxRadio>
+);
 
 Checkbox.propTypes = {
    /** Checkbox is selected. */
    checked: PropTypes.bool,
+   /** Children will supercede the label if provided. */
+   children: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.node,
+      PropTypes.arrayOf(PropTypes.node),
+   ]),
    /** Set class name of containing element. */
    className: PropTypes.string,
    /** Indicates that the form control is not available for interaction. */
    disabled: PropTypes.bool,
    /** Represents a caption for the form control. */
    label: PropTypes.string,
+   /** Override default label margin */
+   labelMargin: PropTypes.string,
    /** The value of the control. */
    value: PropTypes.string,
    /** Callback when focus is removed. */
@@ -32,9 +44,11 @@ Checkbox.propTypes = {
 
 Checkbox.defaultProps = {
    checked: false,
+   children: null,
    className: '',
    disabled: false,
    label: '',
+   labelMargin: null,
    value: 'on',
    onBlur: () => {},
    onChange: () => {},

--- a/src/components/Checkbox/Checkbox.mdx
+++ b/src/components/Checkbox/Checkbox.mdx
@@ -52,6 +52,20 @@ import { Playground, PropsTable } from 'docz'
   />
 </Playground>
 
+### With children
+<Playground>
+  <Checkbox label="Ignored in the presence of children">
+     Normal Text <em>Em Text</em> <strong>Strong Text</strong>
+  </Checkbox>
+</Playground>
+
+### Custom label margin
+
+<Playground>
+  <Checkbox labelMargin="100px" label="Mind the gap" />
+</Playground>
+
+
 ## Props
 
 <PropsTable of={Checkbox} />

--- a/src/components/Checkbox/Checkbox.test.jsx
+++ b/src/components/Checkbox/Checkbox.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Checkbox from './Checkbox';
+
+test('renders without crashing', () => {
+   const tree = renderer.create(<Checkbox />).toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with label', () => {
+   const tree = renderer.create(<Checkbox label="Test Label" />).toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with children', () => {
+   const tree = renderer
+      .create(
+         <Checkbox>
+            Normal Text
+            <strong>Strong</strong>
+         </Checkbox>,
+      )
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});
+
+test('renders with custom margin', () => {
+   const tree = renderer
+      .create(<Checkbox label="Test Label" labelMargin="100px" />)
+      .toJSON();
+   expect(tree).toMatchSnapshot();
+});

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.jsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.jsx.snap
@@ -1,0 +1,352 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders with children 1`] = `
+.glamor-3,
+[data-glamor-3] {
+  display: -webkit-inline-box;
+  display: -moz-inline-box;
+  display: -ms-inline-flexbox;
+  display: -webkit-inline-flex;
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  font-size: 16px;
+  color: rgba(0, 3, 6, 0.87);
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+}
+
+.glamor-1,
+[data-glamor-1] {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  color: transparent;
+  stroke-width: 2;
+  box-sizing: content-box;
+  line-height: 0;
+  flex-shrink: 0;
+  transition: all 150ms ease-in-out;
+  background-color: #FFFFFF;
+  border: 1px solid rgba(0, 3, 6, 0.26);
+  border-radius: 4px;
+  -webkit-flex-shrink: 0;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  margin-left: 16px;
+  line-height: 1.25;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
+<label
+  className="glamor-3"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <input
+    checked={false}
+    className="glamor-0"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onInvalid={[Function]}
+    type="checkbox"
+    value="on"
+  />
+  <span
+    className="glamor-1"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"100%\\" height=\\"100%\\" viewBox=\\"0 0 24 24\\" fill=\\"none\\" stroke=\\"currentColor\\" stroke-width=\\"inherit\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" class=\\"feather feather-check\\"><polyline points=\\"20 6 9 17 4 12\\"></polyline></svg>",
+      }
+    }
+  />
+  <span
+    className="glamor-2"
+  >
+    Normal Text
+    <strong>
+      Strong
+    </strong>
+  </span>
+</label>
+`;
+
+exports[`renders with custom margin 1`] = `
+.glamor-3,
+[data-glamor-3] {
+  display: -webkit-inline-box;
+  display: -moz-inline-box;
+  display: -ms-inline-flexbox;
+  display: -webkit-inline-flex;
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  font-size: 16px;
+  color: rgba(0, 3, 6, 0.87);
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+}
+
+.glamor-1,
+[data-glamor-1] {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  color: transparent;
+  stroke-width: 2;
+  box-sizing: content-box;
+  line-height: 0;
+  flex-shrink: 0;
+  transition: all 150ms ease-in-out;
+  background-color: #FFFFFF;
+  border: 1px solid rgba(0, 3, 6, 0.26);
+  border-radius: 4px;
+  -webkit-flex-shrink: 0;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  margin-left: 100px;
+  line-height: 1.25;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
+<label
+  className="glamor-3"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <input
+    checked={false}
+    className="glamor-0"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onInvalid={[Function]}
+    type="checkbox"
+    value="on"
+  />
+  <span
+    className="glamor-1"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"100%\\" height=\\"100%\\" viewBox=\\"0 0 24 24\\" fill=\\"none\\" stroke=\\"currentColor\\" stroke-width=\\"inherit\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" class=\\"feather feather-check\\"><polyline points=\\"20 6 9 17 4 12\\"></polyline></svg>",
+      }
+    }
+  />
+  <span
+    className="glamor-2"
+  >
+    Test Label
+  </span>
+</label>
+`;
+
+exports[`renders with label 1`] = `
+.glamor-3,
+[data-glamor-3] {
+  display: -webkit-inline-box;
+  display: -moz-inline-box;
+  display: -ms-inline-flexbox;
+  display: -webkit-inline-flex;
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  font-size: 16px;
+  color: rgba(0, 3, 6, 0.87);
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+}
+
+.glamor-1,
+[data-glamor-1] {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  color: transparent;
+  stroke-width: 2;
+  box-sizing: content-box;
+  line-height: 0;
+  flex-shrink: 0;
+  transition: all 150ms ease-in-out;
+  background-color: #FFFFFF;
+  border: 1px solid rgba(0, 3, 6, 0.26);
+  border-radius: 4px;
+  -webkit-flex-shrink: 0;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  margin-left: 16px;
+  line-height: 1.25;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
+<label
+  className="glamor-3"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <input
+    checked={false}
+    className="glamor-0"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onInvalid={[Function]}
+    type="checkbox"
+    value="on"
+  />
+  <span
+    className="glamor-1"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"100%\\" height=\\"100%\\" viewBox=\\"0 0 24 24\\" fill=\\"none\\" stroke=\\"currentColor\\" stroke-width=\\"inherit\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" class=\\"feather feather-check\\"><polyline points=\\"20 6 9 17 4 12\\"></polyline></svg>",
+      }
+    }
+  />
+  <span
+    className="glamor-2"
+  >
+    Test Label
+  </span>
+</label>
+`;
+
+exports[`renders without crashing 1`] = `
+.glamor-3,
+[data-glamor-3] {
+  display: -webkit-inline-box;
+  display: -moz-inline-box;
+  display: -ms-inline-flexbox;
+  display: -webkit-inline-flex;
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  font-size: 16px;
+  color: rgba(0, 3, 6, 0.87);
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.glamor-0,
+[data-glamor-0] {
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+}
+
+.glamor-1,
+[data-glamor-1] {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  color: transparent;
+  stroke-width: 2;
+  box-sizing: content-box;
+  line-height: 0;
+  flex-shrink: 0;
+  transition: all 150ms ease-in-out;
+  background-color: #FFFFFF;
+  border: 1px solid rgba(0, 3, 6, 0.26);
+  border-radius: 4px;
+  -webkit-flex-shrink: 0;
+  -webkit-transition: all 150ms ease-in-out;
+  -moz-transition: all 150ms ease-in-out;
+}
+
+.glamor-2,
+[data-glamor-2] {
+  margin-left: 16px;
+  line-height: 1.25;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
+<label
+  className="glamor-3"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <input
+    checked={false}
+    className="glamor-0"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onInvalid={[Function]}
+    type="checkbox"
+    value="on"
+  />
+  <span
+    className="glamor-1"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"100%\\" height=\\"100%\\" viewBox=\\"0 0 24 24\\" fill=\\"none\\" stroke=\\"currentColor\\" stroke-width=\\"inherit\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" class=\\"feather feather-check\\"><polyline points=\\"20 6 9 17 4 12\\"></polyline></svg>",
+      }
+    }
+  />
+  <span
+    className="glamor-2"
+  >
+    
+  </span>
+</label>
+`;

--- a/src/internal/CheckboxRadio.jsx
+++ b/src/internal/CheckboxRadio.jsx
@@ -38,11 +38,11 @@ const Input = glamorous.input({
    whiteSpace: 'nowrap',
 });
 
-const LabelText = glamorous.span({
-   marginLeft: spacing[3],
+const LabelText = glamorous.span(({ labelMargin }) => ({
+   marginLeft: labelMargin || spacing[3],
    lineHeight: lineHeight.title,
    userSelect: 'none',
-});
+}));
 
 const InputIcon = glamorous(Icon)(
    {
@@ -50,6 +50,7 @@ const InputIcon = glamorous(Icon)(
       width: 16,
       height: 16,
       lineHeight: 0,
+      flexShrink: 0,
       transition: `all ${transition.duration} ${transition.easing}`,
       color: 'transparent',
       backgroundColor: color.white,
@@ -96,11 +97,13 @@ class CheckboxRadio extends React.PureComponent {
 
    render() {
       const {
+         children,
          className,
          checked,
          disabled,
          domProps,
          label,
+         labelMargin,
          onChange,
          onInvalid,
          onMouseEnter,
@@ -151,7 +154,7 @@ class CheckboxRadio extends React.PureComponent {
                <Input {...propsInput} />
             </withDomProps.Target>
             <InputIcon {...propsInputIcon} />
-            <LabelText>{label}</LabelText>
+            <LabelText labelMargin={labelMargin}>{children || label}</LabelText>
          </Label>
       );
    }


### PR DESCRIPTION
We want to be able to put more complex elements in the label than
just text. We also want to be able to specify the margin rather than use
the rather luxurious default spacing.

This also fixes a missing flex-shrink setting that would make skinny checkboxes
at narrow screen widths.