### PR TITLE
Replace iFixit/feather with feather-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12903,10 +12903,19 @@
       }
     },
     "feather-icons": {
-      "version": "github:iFixit/feather#7921f659b662e8b6d19b35598e97dd01e6f4745f",
-      "from": "github:iFixit/feather",
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-4.28.0.tgz",
+      "integrity": "sha512-gRdqKESXRBUZn6Nl0VBq2wPHKRJgZz7yblrrc2lYsS6odkNFDnA4bqvrlEVRUPjE1tFax+0TdbJKZ31ziJuzjg==",
       "requires": {
-        "classnames": "^2.2.5"
+        "classnames": "^2.2.5",
+        "core-js": "^3.1.3"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+          "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
+        }
       }
     },
     "figgy-pudding": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^16.4.1"
   },
   "dependencies": {
-    "feather-icons": "github:iFixit/feather",
+    "feather-icons": "^4.28.0",
     "prop-types": "^15.6.1",
     "react-star-ratings": "^2.3.0",
     "styled-components": "^4.0.0"


### PR DESCRIPTION
This unblocks development on Valkyrie which was failing on docker builds
due to npm install failing to install iFixit/feather from within a
docker image.

QA
===

Use this search to find where else we use toolbox
https://github.com/search?q=org%3AiFixit+toolbox+filename%3Apackage.json&type=Code

Test our usage of toolbox in those places. Happy to help figure this out.
