### PR TITLE
Use node 14 for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
 notifications:
   email: false
 node_js:
-  - '8'
+  - '14'
 install:
   - npm install
   - npm install -g codecov


### PR DESCRIPTION
This is ultimately blocking some Valkyrie work.

Semantic-release package expects node 10 or higher. It seems that we haven't updated the NPM registry with a new version of this package since Sept 2019, even though we've merged a few PRs since then. That doesn't put us super-far behind, but #62 has a change that we want to get live.

<details><summary>Excerpt of log from last master Travis build</summary>

```
[Travis Deploy Once]: There is only one job for this build.
> @ifixit/toolbox@0.0.0-development semantic-release /home/travis/build/iFixit/toolbox
> semantic-release
[semantic-release]: node version >=10.18 is required. Found v8.17.0.
See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md for more details and solutions.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ifixit/toolbox@0.0.0-development semantic-release: `semantic-release`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @ifixit/toolbox@0.0.0-development semantic-release script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2021-02-17T18_59_38_135Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ifixit/toolbox@0.0.0-development travis-deploy-once: `travis-deploy-once "npm run semantic-release"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @ifixit/toolbox@0.0.0-development travis-deploy-once script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2021-02-17T18_59_38_152Z-debug.log
```

</details>


QA
===

I tested some of the npm scripts (listed in `package.json` in the `scripts` key) with node 14.


Setup

1. To use node 14 I used the nave package. `npx nave use 14`. 
2. Did my testing.
3. Exited the nave environment with control-d or `exit`.

The docz pages seem to behave the same.

Finally, I diffed the build output of node 8 vs node 14.

1. I cloned this repo into ~/toolbox2 (in addition to my original clone in ~/toolbox).
2. Using nave, I entered ~/toolbox with node 14
3. I entered ~/toolbox2 with node 8.
4. In both, I ran `npm install && npm run build`
5. I then diffed the output (the `dist/` directories and contents) `diff --recursive toolbox/dist/ toolbox2/dist/` and got no output (no diff)


